### PR TITLE
Verificação da flag "ii" na lista "dpkg -l"

### DIFF
--- a/Linux Mint 19.x posinstall Diolinux.sh
+++ b/Linux Mint 19.x posinstall Diolinux.sh
@@ -77,7 +77,7 @@ sudo dpkg -i $DIRETORIO_DOWNLOADS/*.deb
 
 # Instalar programas no apt
 for nome_do_programa in ${PROGRAMAS_PARA_INSTALAR[@]}; do
-  if ! dpkg -l | grep -q $nome_do_programa; then # Só instala se já não estiver instalado
+  if ! dpkg -l $nome_do_programa 2> /dev/null | grep -q "^ii"; then # Só instala se já não estiver instalado
     apt install "$nome_do_programa" -y
   else
     echo "[INSTALADO] - $nome_do_programa"


### PR DESCRIPTION
Nem todos os pacotes listados pelo "dpkg -l" estão instalados no sistema. Para garantir que o pacote está realmente instalado é necessário verificar o flag "ii". Os flags dos pacotes podem indicar por exemplo: pacote removido, parcialmente instalado, mantido...